### PR TITLE
Ignore Python virtual environment directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ __pycache__/
 
 # Environment & IDE
 .env
+.venv/
+venv/
 .vscode/
 .idea/
 


### PR DESCRIPTION
Prevents accidental commits of local venv/.venv folders.