### PR TITLE
feat: network backpressure via ack-pacing + client auto-pause buffering

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,7 +253,7 @@ function connectWebSocket() {
                     audioEl.src = `/audio${qs}t=${Date.now()}`;
                     audioEl.volume = volumeSlider ? volumeSlider.value : 1.0;
                     audioEl.load();
-                    audioEl.play().catch(() => {});
+                    safePlay();
 
                     // Wait for audio to actually start playing
                     if (audioEl.readyState >= 3) {
@@ -445,8 +445,40 @@ function renderFrame(now) {
 // only once the buffer has refilled — YouTube-style rebuffering. A *CPU*
 // underrun is handled server-side by frame-dropping instead, so this path only
 // fires when frames simply haven't arrived over the wire yet.
-const BUFFER_RESUME = 8;   // frames buffered before we resume after an underrun
+const BUFFER_RESUME = 8;    // healthy buffer depth that resumes immediately
+const MIN_RESUME = 1;       // minimum frames we'll resume with after a long wait
+const MAX_BUFFER_WAIT = 1500; // ms — past this we resume with whatever we have
 let bufferStartTime = 0;
+// Invalidates in-flight bufferingPoll loops. Every entry into buffering bumps
+// this and captures it; a poll whose token is stale (e.g. a seek arrived mid
+// buffer) bails instead of racing a second resume / render loop.
+let bufferGen = 0;
+
+// ── SAFE AUDIO PLAY / PAUSE ──
+// HTMLMediaElement.play() returns a promise that REJECTS with a DOMException if
+// the element is paused before play() settles. That happens here whenever a
+// play() (seek / startup / resume) is followed immediately by a buffering
+// underrun that calls pause() on a still-empty frame buffer — it permanently
+// wedges the browser's audio state (A/V desync that never recovers). Serializing
+// pause() behind the pending play() promise makes the pair race-free.
+let audioPlayPromise = null;
+function safePlay() {
+    if (!audioEl) return;
+    audioPlayPromise = audioEl.play();
+    if (audioPlayPromise && audioPlayPromise.catch) {
+        audioPlayPromise.catch(() => {}).finally(() => { audioPlayPromise = null; });
+    }
+}
+function safePause() {
+    if (!audioEl) return;
+    if (audioPlayPromise && audioPlayPromise.then) {
+        // play() hasn't settled yet — wait for it, then pause, so we never
+        // interrupt it mid-flight.
+        audioPlayPromise.then(() => audioEl.pause()).catch(() => {});
+    } else {
+        audioEl.pause();
+    }
+}
 
 function maybeBuffer(masterClock) {
     if (state !== 'PLAYING') return;
@@ -454,28 +486,36 @@ function maybeBuffer(masterClock) {
     if (duration && masterClock >= duration - 1) return;
     state = 'BUFFERING';
     bufferStartTime = performance.now();
-    if (audioEl && !audioEl.paused) audioEl.pause();
+    if (audioEl && !audioEl.paused) safePause();
     if (statusEl) { statusEl.textContent = '⟳ Buffering…'; statusEl.style.color = '#888'; }
-    requestAnimationFrame(bufferingPoll);
+    const gen = ++bufferGen;
+    requestAnimationFrame(() => bufferingPoll(gen));
 }
 
-function bufferingPoll() {
+function bufferingPoll(gen) {
+    if (gen !== bufferGen) return;               // superseded by a newer seek/buffer
     if (state !== 'BUFFERING') return;           // user paused, seeked, or stream ended
     if (!ws || ws.readyState !== WebSocket.OPEN) { finishStream(); return; }
-    if (frameBuffer.length >= BUFFER_RESUME) {
+    // Resume on a healthy buffer, OR — to avoid a permanent stall on a slow link
+    // where BUFFER_RESUME frames may never stack up (initial 3G start, paced
+    // delivery) — once we've waited long enough and have at least one frame to
+    // show. Without this fallback the strict >= BUFFER_RESUME gate deadlocks.
+    const waited = performance.now() - bufferStartTime;
+    if (frameBuffer.length >= BUFFER_RESUME ||
+        (frameBuffer.length >= MIN_RESUME && waited >= MAX_BUFFER_WAIT)) {
         // Frozen wall time must be credited back so the wall clock (no-audio
         // branch) doesn't think it's behind and burst. The audio branch needs no
         // adjustment: a paused <audio> element holds currentTime on its own.
         streamStartTime += performance.now() - bufferStartTime;
         bufferStartTime = 0;
         state = 'PLAYING';
-        if (audioEl && audioEl.paused) audioEl.play().catch(() => {});
+        if (audioEl && audioEl.paused) safePlay();
         if (statusEl) statusEl.style.color = 'var(--accent-color)';
         lastRenderTime = performance.now();
         requestAnimationFrame(renderFrame);
         return;
     }
-    requestAnimationFrame(bufferingPoll);
+    requestAnimationFrame(() => bufferingPoll(gen));
 }
 
 // ═══════════════════════════════════════
@@ -537,6 +577,7 @@ function togglePause() {
         // Fold the in-progress stall into the wall clock, then pause as if playing
         // (audio is already paused, bufferingPoll exits once state changes).
         if (bufferStartTime) { streamStartTime += performance.now() - bufferStartTime; bufferStartTime = 0; }
+        bufferGen++;   // kill the in-flight buffering loop
         state = 'PLAYING';
     }
     if (state === 'PLAYING') {
@@ -544,7 +585,7 @@ function togglePause() {
         pauseStartTime = performance.now();
         
         if (audioEl && !audioEl.paused) {
-            audioEl.pause();
+            safePause();
         }
         if (ws && ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ type: 'pause', paused: true }));
@@ -567,7 +608,7 @@ function togglePause() {
         
         // Restore audio playback
         if (audioEl && audioEl.paused) {
-            audioEl.play().catch(() => {});
+            safePlay();
         }
 
         // Flush stale buffer frames — A/V sync catch-up handles the rest
@@ -605,39 +646,40 @@ function doSeek(targetSec) {
         ws.send(JSON.stringify({ type: 'seek', time: targetSec }));
     }
 
-    // Drop stale frames, then restart audio from the seek point
+    // Drop stale frames, then reload audio from the seek point.
     frameBuffer.length = 0;
     audioOffset = targetSec;
 
+    const wasActive = (state === 'PLAYING' || state === 'BUFFERING');
+
     if (audioEl) {
+        // Reload the audio element from the new position but DON'T play yet.
         audioEl.pause();
         audioEl.src = `/audio?v=${currentQueueIdx}&start=${targetSec}&t=${Date.now()}`;
         audioEl.load();
+    }
 
-        if (state === 'PLAYING' || state === 'BUFFERING') {
-            state = 'PLAYING';   // a seek supersedes an in-progress buffering stall
-            bufferStartTime = 0;
-            readyToRender = false;
-            audioEl.play().catch(() => {});
-            const onAudioStart = () => {
-                if (!readyToRender) {
-                    readyToRender = true;
-                    streamStartTime = performance.now() - (targetSec * 1000.0);
-                    lastRenderTime = performance.now();
-                    lastFpsUpdate = performance.now();
-                    frameCount = 0;
-                    requestAnimationFrame(renderFrame);
-                }
-            };
-            if (audioEl.readyState >= 3) onAudioStart();
-            else {
-                audioEl.addEventListener('playing', onAudioStart, { once: true });
-                setTimeout(onAudioStart, 500);
-            }
-        } else {
-            streamStartTime = performance.now() - (targetSec * 1000.0);
-        }
+    if (wasActive) {
+        // The buffer is now empty. If we fired audioEl.play() here, the very next
+        // renderFrame would underrun and call maybeBuffer() → pause(), interrupting
+        // the pending play() promise (DOMException) and desyncing A/V. Instead we
+        // enter BUFFERING and let bufferingPoll start audio + rendering only once
+        // frames for the new position have actually arrived.
+        readyToRender = true;
+        bufferStartTime = performance.now();
+        // Encode the seek target into streamStartTime so bufferingPoll's
+        // "+= now - bufferStartTime" credit lands the wall clock exactly at
+        // targetSec on resume. (Audio branch is covered by audioOffset.)
+        streamStartTime = bufferStartTime - (targetSec * 1000.0);
+        lastRenderTime = bufferStartTime;
+        lastFpsUpdate = bufferStartTime;
+        frameCount = 0;
+        state = 'BUFFERING';
+        if (statusEl) { statusEl.textContent = '⟳ Buffering…'; statusEl.style.color = '#888'; }
+        const gen = ++bufferGen;
+        requestAnimationFrame(() => bufferingPoll(gen));
     } else {
+        // Paused / idle: just reposition the clock; playback stays where it was.
         streamStartTime = performance.now() - (targetSec * 1000.0);
     }
 }

--- a/app.js
+++ b/app.js
@@ -42,6 +42,12 @@ let state = 'IDLE'; // IDLE | PLAYING | PAUSED
 let ws = null;
 let bufferReportTimer = null; // periodic backlog report to the server (backpressure)
 const frameBuffer = [];
+// Highest frame index we've actually RECEIVED off the wire. Reported to the
+// server (ack pacing) so it can pace sending to real delivery when the network
+// is the bottleneck — the client's decode-buffer depth stays 0 in that case and
+// can't reveal it. WebSocket preserves order, so "last received" == highest;
+// after a seek it simply follows the new (lower) indices down. -1 = none yet.
+let lastReceivedIndex = -1;
 const BUFFER_SIZE = 4;
 let codecDecoder = null; // Adaptive codec decoder (codec.js)
 let targetFps = 24;
@@ -270,11 +276,15 @@ function connectWebSocket() {
             const text = event.data;
             const newlineIdx = text.indexOf('\n');
             const frameIndex = parseInt(text.substring(0, newlineIdx));
+            lastReceivedIndex = frameIndex;
             const frameTime = frameIndex / targetFps;
             const frameData = text.substring(newlineIdx + 1);
             frameBuffer.push({ data: frameData, time: frameTime });
         } else {
-            // Binary Frames — decoded via adaptive codec (raw/zlib/delta)
+            // Binary Frames — decoded via adaptive codec (raw/zlib/delta).
+            // The 4-byte big-endian header is the frame index even under the
+            // adaptive codec, so we can ack receipt now, before the async decode.
+            lastReceivedIndex = new DataView(event.data).getUint32(0, false);
             if (codecDecoder) {
                 framesInFlight++;
                 codecDecoder.decode(event.data).then(({ frameIndex, frame }) => {
@@ -345,14 +355,14 @@ function renderFrame(now) {
         }
     }
 
-    if (frameBuffer.length === 0) return;
+    if (frameBuffer.length === 0) { maybeBuffer(masterClock); return; }
 
     // A/V Sync: Drop frames that are too far behind the master clock (catch up)
     while (frameBuffer.length > 0 && frameBuffer[0].time < masterClock - 0.1) {
         frameBuffer.shift();
     }
-    
-    if (frameBuffer.length === 0) return;
+
+    if (frameBuffer.length === 0) { maybeBuffer(masterClock); return; }
 
     // A/V Sync: Wait if the frame is in the future
     if (frameBuffer[0].time > masterClock + 0.05) {
@@ -425,20 +435,73 @@ function renderFrame(now) {
 }
 
 // ═══════════════════════════════════════
+//  AUTO-PAUSE BUFFERING (network underrun)
+// ═══════════════════════════════════════
+// On a slow *network* the server paces sending (it never drops scenes from a
+// finite video), so the decode buffer can run dry. We must not let the audio
+// master clock keep advancing past the video we actually have — that desyncs
+// A/V and makes the late frames arrive "stale" (time < masterClock - 0.1) and
+// get discarded. So on underrun we freeze the clock (pause audio) and resume
+// only once the buffer has refilled — YouTube-style rebuffering. A *CPU*
+// underrun is handled server-side by frame-dropping instead, so this path only
+// fires when frames simply haven't arrived over the wire yet.
+const BUFFER_RESUME = 8;   // frames buffered before we resume after an underrun
+let bufferStartTime = 0;
+
+function maybeBuffer(masterClock) {
+    if (state !== 'PLAYING') return;
+    // Don't mistake the natural end of the video for a network underrun.
+    if (duration && masterClock >= duration - 1) return;
+    state = 'BUFFERING';
+    bufferStartTime = performance.now();
+    if (audioEl && !audioEl.paused) audioEl.pause();
+    if (statusEl) { statusEl.textContent = '⟳ Buffering…'; statusEl.style.color = '#888'; }
+    requestAnimationFrame(bufferingPoll);
+}
+
+function bufferingPoll() {
+    if (state !== 'BUFFERING') return;           // user paused, seeked, or stream ended
+    if (!ws || ws.readyState !== WebSocket.OPEN) { finishStream(); return; }
+    if (frameBuffer.length >= BUFFER_RESUME) {
+        // Frozen wall time must be credited back so the wall clock (no-audio
+        // branch) doesn't think it's behind and burst. The audio branch needs no
+        // adjustment: a paused <audio> element holds currentTime on its own.
+        streamStartTime += performance.now() - bufferStartTime;
+        bufferStartTime = 0;
+        state = 'PLAYING';
+        if (audioEl && audioEl.paused) audioEl.play().catch(() => {});
+        if (statusEl) statusEl.style.color = 'var(--accent-color)';
+        lastRenderTime = performance.now();
+        requestAnimationFrame(renderFrame);
+        return;
+    }
+    requestAnimationFrame(bufferingPoll);
+}
+
+// ═══════════════════════════════════════
 //  CLEANUP
 // ═══════════════════════════════════════
 
 // ── BACKPRESSURE REPORTING ──
-// Tell the server how many frames are currently stuck in the decode pipeline
-// (framesInFlight). When it grows, the client is CPU-bound, and the server 
-// drops frames instead of making us inflate+delta-patch them.
+// Two independent signals, because the client can fall behind for two unrelated
+// reasons and only the client can see them:
+//   depth = framesInFlight — frames stuck in the decode pipeline. Grows when the
+//           client is CPU-bound; the server drops frames instead of making us
+//           inflate+delta-patch frames we'd only discard. (Note: read-ahead in
+//           frameBuffer is healthy and deliberately NOT counted, to avoid
+//           false-positive drops on fast networks.)
+//   recv  = lastReceivedIndex — highest frame index actually received off the
+//           wire. Lets the server detect a *network* bottleneck (sent >> acked)
+//           that depth can't, since choked frames never reach the decoder.
 let framesInFlight = 0;
 
 function startBufferReports() {
     stopBufferReports();
     bufferReportTimer = setInterval(() => {
-        if (ws && ws.readyState === WebSocket.OPEN && state === 'PLAYING') {
-            ws.send(JSON.stringify({ type: 'buffer', depth: framesInFlight }));
+        // Keep reporting while BUFFERING too: acks (recv) must keep flowing or the
+        // server's ack-pacing would wait forever for frames we're trying to buffer.
+        if (ws && ws.readyState === WebSocket.OPEN && (state === 'PLAYING' || state === 'BUFFERING')) {
+            ws.send(JSON.stringify({ type: 'buffer', depth: framesInFlight, recv: lastReceivedIndex }));
         }
     }, 250);
 }
@@ -470,6 +533,12 @@ function finishStream() {
 // ═══════════════════════════════════════
 
 function togglePause() {
+    if (state === 'BUFFERING') {
+        // Fold the in-progress stall into the wall clock, then pause as if playing
+        // (audio is already paused, bufferingPoll exits once state changes).
+        if (bufferStartTime) { streamStartTime += performance.now() - bufferStartTime; bufferStartTime = 0; }
+        state = 'PLAYING';
+    }
     if (state === 'PLAYING') {
         state = 'PAUSED';
         pauseStartTime = performance.now();
@@ -545,7 +614,9 @@ function doSeek(targetSec) {
         audioEl.src = `/audio?v=${currentQueueIdx}&start=${targetSec}&t=${Date.now()}`;
         audioEl.load();
 
-        if (state === 'PLAYING') {
+        if (state === 'PLAYING' || state === 'BUFFERING') {
+            state = 'PLAYING';   // a seek supersedes an in-progress buffering stall
+            bufferStartTime = 0;
             readyToRender = false;
             audioEl.play().catch(() => {});
             const onAudioStart = () => {
@@ -577,7 +648,7 @@ function getMasterClock() {
 }
 
 function skip(delta) {
-    if (state !== 'PLAYING' && state !== 'PAUSED') return;
+    if (state !== 'PLAYING' && state !== 'PAUSED' && state !== 'BUFFERING') return;
     if (!duration) return;
     doSeek(getMasterClock() + delta);
 }

--- a/stream_server.py
+++ b/stream_server.py
@@ -678,6 +678,18 @@ async def websocket_endpoint(websocket: WebSocket):
             client_backlog = 0   # latest depth reported by the client (0 = unknown/healthy)
             consec_drops = 0
 
+            # ── TRANSPORT-SIDE BACKPRESSURE (ack pacing) ──
+            # client_backlog (framesInFlight) only sees the client's *CPU*
+            # bottleneck. A *network* bottleneck is invisible locally — uvicorn does
+            # not back-pressure the ASGI send, so send_bytes returns immediately. The
+            # client therefore also reports the highest frame index it has *received*
+            # ("recv"); we keep at most INFLIGHT_HIGH frames sent-but-unacked. The two
+            # bottlenecks get opposite treatment in the loop below (pace vs drop).
+            INFLIGHT_HIGH = BACKLOG_HIGH
+            last_recv_index = -1       # highest frame index the client has acked (-1 = none)
+            last_sent_index = -1       # highest frame index we have actually sent
+            was_network_paced = False  # true while we're holding for acks to catch up
+
             _loop = asyncio.get_event_loop()
 
             try:
@@ -698,23 +710,61 @@ async def websocket_endpoint(websocket: WebSocket):
                             bw_start_time = time.time()
                             client_backlog = 0  # stale across a seek
                             consec_drops = 0
+                            last_recv_index = -1  # acks for old indices are stale
+                            last_sent_index = -1
+                            was_network_paced = False
                         elif msg.get("type") == "buffer":
                             # Client's current decoded-frame backlog (frameBuffer.length).
                             try:
                                 client_backlog = max(0, int(msg.get("depth", 0)))
                             except (TypeError, ValueError):
                                 client_backlog = 0
+                            # Highest frame index the client has actually received.
+                            # Optional/back-compat: older clients omit it.
+                            if "recv" in msg:
+                                try:
+                                    last_recv_index = int(msg["recv"])
+                                except (TypeError, ValueError):
+                                    pass
 
                     if is_paused:
                         await asyncio.sleep(0.1)
                         continue
 
-                    # ── BACKPRESSURE ──
-                    # If the client is behind, skip this frame instead of sending one
-                    # it will only decode-then-drop. Advancing the source keeps video
-                    # time-aligned with the audio/wall clock; prev_frame is held so the
-                    # next sent frame is a correct delta across the gap. MAX_CONSEC_DROPS
-                    # caps the gap and guarantees we never starve the client.
+                    # ── NETWORK BACKPRESSURE: pace, never drop ──
+                    # ASCILINE plays finite videos only (ytdl rejects live URLs), so a
+                    # slow *network* must not cost scenes. Instead of dropping, stop
+                    # producing and let the wire drain until the client's acks catch
+                    # up. Bounding in-flight (sent - acked) caps the bytes queued ahead
+                    # of the keep-alive ping — that pile-up is what reset the socket on
+                    # a slow link (WinError 10054), and the drop path couldn't see it
+                    # because choked frames never reach the client's decode buffer and
+                    # so never show up as client_backlog. The client freezes its master
+                    # clock (auto-pause buffering) while we're paced, so audio never
+                    # runs past the video we've delivered. last_recv < 0 = no ack yet →
+                    # don't pace (the startup burst fills the client's jitter buffer).
+                    # NOTE: when live-source support lands, live should DROP here
+                    # instead (you can't buffer your way back to the real-time edge).
+                    network_behind = (last_recv_index >= 0 and
+                                      last_sent_index - last_recv_index > INFLIGHT_HIGH)
+                    if network_behind:
+                        was_network_paced = True
+                        await asyncio.sleep(frame_t)
+                        continue
+                    if was_network_paced:
+                        # Acks caught up: rebase the wall clock so we resume at natural
+                        # cadence instead of bursting to reclaim the time spent paced.
+                        was_network_paced = False
+                        start_time = _loop.time() - (frame_index * frame_t)
+
+                    # ── CPU BACKPRESSURE: drop ──
+                    # The client's decode pipeline (framesInFlight) is the bottleneck.
+                    # Waiting can't clear a CPU deficit, so skip this frame instead of
+                    # sending one it would only decode-then-drop. Advancing the source
+                    # keeps video time-aligned with the audio/wall clock; prev_frame is
+                    # held so the next sent frame is a correct delta across the gap.
+                    # MAX_CONSEC_DROPS caps the gap and guarantees we never starve the
+                    # client.
                     if client_backlog > BACKLOG_HIGH and consec_drops < MAX_CONSEC_DROPS:
                         advanced = await _loop.run_in_executor(None, advance_one)
                         if not advanced:
@@ -742,6 +792,7 @@ async def websocket_endpoint(websocket: WebSocket):
                         await websocket.send_text(data)
                     else:
                         await websocket.send_bytes(data)
+                    last_sent_index = frame_index  # for ack-paced backpressure
 
                     bw_bytes_sent += wire_size
                     bw_raw_bytes += raw_size

--- a/test/test_transport_backpressure.js
+++ b/test/test_transport_backpressure.js
@@ -1,0 +1,222 @@
+/**
+ * Live behavioral test for ACK-PACED (network) backpressure.
+ *
+ * test_backpressure_live.js proves the CLIENT-backlog (CPU) path: a client that
+ * *reports* a high decode backlog gets a thinned (dropped) stream. That path has
+ * a blind spot — when the NETWORK is the bottleneck the frames pile up in
+ * buffers between server and client, the client's decode buffer stays at 0, and
+ * the server (uvicorn does not back-pressure the ASGI send) keeps producing
+ * until the pipe chokes and the keep-alive ping starves, resetting the socket
+ * (raised by @YusufB5 testing PR #30 under Chrome "Slow 3G").
+ *
+ * The fix: the client also reports the highest frame index it has *received*
+ * ("recv"), and on a network bottleneck the server PACES — it stops producing
+ * until acks catch up, rather than dropping. ASCILINE plays finite videos only,
+ * so a slow network must never cost scenes; dropping is reserved for the CPU
+ * path (you can't wait out a CPU deficit). This test reproduces the slow link
+ * with a throttling TCP proxy. Both clients report depth:0 (no CPU backlog) and
+ * a truthful recv, so the only thing in play is the network (ack) path. We
+ * assert:
+ *
+ *   - the slow client's stream is CONTIGUOUS (no skipped indices) -> no scenes
+ *     dropped, and it isn't reset (collect() rejects on socket error)
+ *   - the slow client gets FEWER frames than fast -> it was actually paced
+ *   - a fast client (acks keep up) gets a contiguous stream -> no false pacing
+ *
+ * Requires: ffmpeg + a Python with the server deps. Override interpreter with
+ * ASCIL_PY (e.g. ASCIL_PY=/data/ascil-venv/bin/python).
+ *
+ * Usage: node test/test_transport_backpressure.js
+ */
+const { spawn, execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const net = require('net');
+const path = require('path');
+
+const PY = process.env.ASCIL_PY || 'python3';
+const REPO = path.dirname(__dirname);
+const WINDOW_MS = 14000;         // collection window per client
+const SLOW_BYTES_PER_SEC = 60000;// server->client drip rate (~Slow 3G; ~10x below the ~575 KB/s offered)
+const TICK_MS = 100;             // token-bucket refill interval
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function waitForPort(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tryOnce = () => {
+      const sock = net.connect(port, '127.0.0.1');
+      sock.on('connect', () => { sock.destroy(); resolve(); });
+      sock.on('error', () => {
+        sock.destroy();
+        if (Date.now() > deadline) reject(new Error('server did not start'));
+        else setTimeout(tryOnce, 150);
+      });
+    };
+    tryOnce();
+  });
+}
+
+/**
+ * A TCP proxy that forwards client<->upstream but throttles the upstream->client
+ * direction to exactly `bytesPerSec`. Incoming server data is queued and the
+ * timer releases at most `bytesPerSec * TICK_MS/1000` bytes per tick, SLICING
+ * the head chunk when needed (a naive "pause after the budget is spent" leaks at
+ * one TCP chunk — ~64 KB — per tick). When the queue backs up past ~1s of data
+ * we pause the upstream read, which backpropagates and saturates the server's
+ * OS send buffer — exactly like a slow real link. Returns { port, close }.
+ */
+function startThrottleProxy(upstreamPort, bytesPerSec) {
+  return new Promise((resolve) => {
+    const conns = new Set();
+    const perTick = Math.max(1, Math.floor(bytesPerSec * (TICK_MS / 1000)));
+    const HIGH_WATER = bytesPerSec; // ~1s queued -> stop reading upstream
+    const server = net.createServer((client) => {
+      const upstream = net.connect(upstreamPort, '127.0.0.1');
+      conns.add(client); conns.add(upstream);
+      let queue = [];     // pending server->client buffers
+      let qBytes = 0;
+
+      client.pipe(upstream);            // client->server: unthrottled
+      upstream.on('data', (chunk) => {  // server->client: queued, drained on tick
+        queue.push(chunk); qBytes += chunk.length;
+        if (qBytes > HIGH_WATER) upstream.pause();
+      });
+      const tick = setInterval(() => {
+        let allow = perTick;
+        while (allow > 0 && queue.length) {
+          const head = queue[0];
+          if (head.length <= allow) {
+            client.write(head); allow -= head.length; qBytes -= head.length; queue.shift();
+          } else {
+            client.write(head.subarray(0, allow)); queue[0] = head.subarray(allow);
+            qBytes -= allow; allow = 0;
+          }
+        }
+        if (qBytes < HIGH_WATER) upstream.resume();
+      }, TICK_MS);
+
+      const shut = () => {
+        clearInterval(tick);
+        try { client.destroy(); } catch (_) {}
+        try { upstream.destroy(); } catch (_) {}
+      };
+      client.on('close', shut); upstream.on('close', shut);
+      client.on('error', shut); upstream.on('error', shut);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        close: () => { for (const c of conns) { try { c.destroy(); } catch (_) {} } server.close(); },
+      });
+    });
+  });
+}
+
+// Collect frame indices for WINDOW_MS. Like the real client, it reports a buffer
+// message with depth:0 (no CPU backlog) and recv = highest index received, so
+// the only thing in play here is the ack-pacing (network) path.
+function collect(port) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws?codec=adaptive`);
+    ws.binaryType = 'arraybuffer';
+    const indices = [];
+    let lastRecv = -1, timer = null, acker = null;
+    const stop = () => {
+      if (timer) clearTimeout(timer);
+      if (acker) clearInterval(acker);
+      try { ws.close(); } catch (_) {}
+      resolve(indices);
+    };
+    ws.onopen = () => {
+      timer = setTimeout(stop, WINDOW_MS);
+      acker = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'buffer', depth: 0, recv: lastRecv }));
+        }
+      }, 250);
+    };
+    ws.onmessage = (ev) => {
+      if (typeof ev.data === 'string') return; // INIT / status
+      const idx = new DataView(ev.data).getUint32(0, false);
+      lastRecv = idx;
+      indices.push(idx);
+    };
+    ws.onerror = (e) => { if (timer) clearTimeout(timer); reject(e.error || new Error('ws error')); };
+  });
+}
+
+function maxGap(indices) {
+  let m = 0;
+  for (let i = 1; i < indices.length; i++) m = Math.max(m, indices[i] - indices[i - 1]);
+  return m;
+}
+
+(async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ascil-tbp-'));
+  const clip = path.join(tmp, 'clip.mp4');
+  let server = null, proxy = null;
+  try {
+    // 18s of full-frame NOISE at 24fps. Real ascii video has high per-frame
+    // entropy; a compressible testsrc would shrink to ~1 KB/s and never
+    // saturate a link. Noise keeps frames incompressible so the offered rate
+    // (~575 KB/s) genuinely exceeds the slow link, just like the real footage
+    // that surfaced this bug.
+    execFileSync('ffmpeg', [
+      '-y', '-f', 'lavfi', '-i', 'testsrc=s=320x240:r=24:d=18',
+      '-vf', 'noise=alls=80:allf=t+u',
+      '-pix_fmt', 'yuv420p', clip,
+    ], { stdio: 'ignore' });
+
+    const port = await freePort();
+    server = spawn(PY, ['stream_server.py', clip, '--mode', '2', '--vol', '0',
+      '--cols', '200', '--no-thumbnails', '--host', '127.0.0.1', '--port', String(port)],
+      { cwd: REPO, stdio: ['pipe', 'ignore', 'ignore'] });
+    server.on('error', (e) => { throw e; });
+    await waitForPort(port, 15000);
+
+    // Fast drain straight to the server (healthy link), then a slow drain
+    // through the throttling proxy. Both report depth:0 and a truthful recv.
+    const fast = await collect(port);
+    proxy = await startThrottleProxy(port, SLOW_BYTES_PER_SEC);
+    const slow = await collect(proxy.port);
+
+    // Reaching this point at all proves the slow link did NOT reset the socket
+    // (collect() rejects on ws error) — that reset was the original slow-link bug.
+    const checks = [
+      ['fast client received frames', fast.length > 5, `got ${fast.length}`],
+      ['fast (healthy link) stream is contiguous', maxGap(fast) <= 1,
+        `maxGap=${maxGap(fast)}`],
+      ['slow client received some frames (not starved/reset)', slow.length > 0,
+        `got ${slow.length}`],
+      ['slow (saturated link) stream is CONTIGUOUS — paced, no scenes dropped',
+        maxGap(slow) <= 1, `maxGap=${maxGap(slow)}`],
+      ['slow received fewer frames than fast — actually paced to the link',
+        slow.length < fast.length, `slow=${slow.length} fast=${fast.length}`],
+    ];
+
+    let failed = 0;
+    for (const [name, ok, why] of checks) {
+      console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : '  -> ' + why}`);
+      if (!ok) failed++;
+    }
+    console.log(`\nfast: ${fast.length} frames (maxGap ${maxGap(fast)})  |  ` +
+      `slow: ${slow.length} frames (maxGap ${maxGap(slow)})`);
+    console.log(`${checks.length - failed}/${checks.length} passed`);
+    process.exitCode = failed === 0 ? 0 : 1;
+  } finally {
+    if (proxy) proxy.close();
+    if (server) server.kill('SIGKILL');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+})().catch((e) => { console.error('ERROR', e); process.exit(2); });


### PR DESCRIPTION
Follow-up to #31. That PR sheds frames when the **client is CPU-bound** (`framesInFlight`). It has a blind spot: when the **network** is the bottleneck, frames pile up in buffers between server and client, the client's decode queue stays at 0, the drop branch never fires, and the server keeps producing into a choked pipe until the keep-alive ping starves and the socket resets — the slow-link reset you hit under Chrome "Slow 3G".

ASCILINE plays finite videos only (`ytdl` rejects live URLs), so a slow network must never cost scenes. Fix is two coordinated parts:

**Server (`stream_server.py`)** — the client now also reports the highest frame index it has *received* (`recv`). The backpressure branch is split:
- **Network bottleneck** (`sent - acked > INFLIGHT_HIGH`) → **pace**: stop producing until acks catch up, rebasing the clock on resume so it doesn't burst. Bounding in-flight caps the bytes queued ahead of the keep-alive ping — which is what prevented the reset. No scenes dropped.
- **CPU bottleneck** (`framesInFlight`) → **drop**, as in #31 (you can't wait out a CPU deficit). Your `framesInFlight` fix is kept as-is.

Two orthogonal signals now: `depth` = framesInFlight (CPU), `recv` (network).

**Client (`app.js`)** — auto-pause buffering. On a decode-buffer underrun it freezes the master clock (pauses audio) and resumes once the buffer refills, YouTube-style, so audio never runs past the delivered video. It keeps acking while buffering, otherwise the server's pacing would deadlock.

**Tests** (`ASCIL_PY=/path/to/venv/bin/python node test/...`):
- `test_transport_backpressure.js` (new) — a throttling TCP proxy reproduces a slow link. The slow client gets a **contiguous** stream (no scenes dropped), paced to the link, and isn't reset; it receives fewer frames than a fast client. The fast client's stream is contiguous (no false pacing).
- `test_backpressure_gap.js` 4/4, `test_backpressure_live.js` 5/5 — the CPU drop path is unchanged.

Rebased cleanly on current `main` — no changes to the logo, prefetch worker, LRU GC, cache limits, or the `render_mode` security check.

Note: when live-source support lands, live should **drop** on a network bottleneck instead of pacing (you can't buffer your way back to the real-time edge) — that's a one-line branch on the same `network_behind` signal.