### PR TITLE
Add static Studio: in-browser drag-and-drop .ascf compiler + player

### DIFF
--- a/static_player/studio/encoder.js
+++ b/static_player/studio/encoder.js
@@ -1,0 +1,149 @@
+/**
+ * encoder.js - client-side ASCILINE .ascf encoder (mirror of codec.py).
+ *
+ * Produces bytes the shipped codec.js decodes exactly. It emits ONLY the tags
+ * codec.js understands: 0 RAW, 1 ZLIB, 2 DELTA. It deliberately does NOT emit
+ * tag 3 (RLE_FULL): the shipped codec.js throws on it, so any .ascf using tag 3
+ * cannot play in the current player. Lossless (tolerance 0). A forced keyframe
+ * every 48 frames bounds delta chains and lets late joiners resync.
+ *
+ * Deflate is pluggable so the same file runs in the browser (pako) and Node
+ * (zlib) - both emit RFC1950 zlib, which codec.js inflates via
+ * DecompressionStream('deflate').
+ *
+ *   makeEncoder(cellBytes, opts?) -> { encode(frame) -> {msg, shown}, reset() }
+ *   ascfHeader(fps, mode, pixel, cols, rows) -> Uint8Array(14)
+ *   encodeFramesToAscf(frames, meta, opts?) -> Uint8Array         (convenience)
+ *
+ * frame / shown are Uint8Array of length rows*cols*cellBytes. Pixel cells are
+ * [B,G,R] (cellBytes 3); ASCII cells are [char,R,G,B] (cellBytes 4).
+ */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  else root.AscilineEncoder = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  const TAG_RAW = 0, TAG_ZLIB = 1, TAG_DELTA = 2;
+  const KEYFRAME_INTERVAL = 48;
+  const DELTA_MAX_FRAC = 0.60; // above this, delta loses; skip building it
+  const ZLIB_MIN_FRAC = 0.10;  // below this, full-frame zlib loses; skip it
+
+  function resolveDeflate(opts) {
+    if (opts && opts.deflate) return opts.deflate;
+    const level = (opts && opts.level != null) ? opts.level : 3;
+    if (typeof pako !== 'undefined') return (u8) => pako.deflate(u8, { level });
+    if (typeof window !== 'undefined' && window.pako) return (u8) => window.pako.deflate(u8, { level });
+    if (typeof require !== 'undefined') {
+      const zlib = require('zlib');
+      return (u8) => new Uint8Array(zlib.deflateSync(Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength), { level }));
+    }
+    throw new Error('encoder: no deflate available (load pako before encoder.js)');
+  }
+
+  function concat(list) {
+    let n = 0; for (const a of list) n += a.length;
+    const out = new Uint8Array(n);
+    let p = 0; for (const a of list) { out.set(a, p); p += a.length; }
+    return out;
+  }
+
+  function msgHeader(frameIndex, tag) {
+    const h = new Uint8Array(5);
+    new DataView(h.buffer).setUint32(0, frameIndex >>> 0, false); // big-endian
+    h[4] = tag;
+    return h;
+  }
+
+  function ascfHeader(fps, mode, pixel, cols, rows) {
+    const h = new Uint8Array(14);
+    const dv = new DataView(h.buffer);
+    h[0] = 0x41; h[1] = 0x53; h[2] = 0x43; h[3] = 0x46; // 'ASCF'
+    dv.setFloat32(4, fps, false);
+    h[8] = mode & 0xff;
+    h[9] = pixel ? 1 : 0;
+    dv.setUint16(10, cols, false);
+    dv.setUint16(12, rows, false);
+    return h;
+  }
+
+  function makeEncoder(cellBytes, opts) {
+    const C = cellBytes;
+    const deflate = resolveDeflate(opts);
+    let prev = null;   // Uint8Array of the last shown frame
+    let index = 0;
+
+    function fullFrame(raw, frameIndex) {
+      // Race ZLIB vs RAW only (no RLE_FULL: shipped codec.js can't decode it).
+      const z = deflate(raw);
+      if (z.length < raw.length) return concat([msgHeader(frameIndex, TAG_ZLIB), z]);
+      return concat([msgHeader(frameIndex, TAG_RAW), raw]);
+    }
+
+    function encode(frame) {
+      const raw = frame instanceof Uint8Array ? frame : new Uint8Array(frame);
+      const frameIndex = index++;
+      const keyframe = prev === null || (frameIndex % KEYFRAME_INTERVAL === 0) || prev.length !== raw.length;
+
+      if (keyframe) {
+        const msg = fullFrame(raw, frameIndex);
+        prev = raw.slice();
+        return { msg, shown: prev };
+      }
+
+      // Lossless changed-cell scan (tolerance 0).
+      const nCells = (raw.length / C) | 0;
+      const changed = [];
+      for (let cell = 0; cell < nCells; cell++) {
+        const o = cell * C;
+        let diff = false;
+        for (let c = 0; c < C; c++) { if (raw[o + c] !== prev[o + c]) { diff = true; break; } }
+        if (diff) changed.push(cell);
+      }
+      const frac = nCells ? changed.length / nCells : 1;
+
+      const candidates = [];
+      if (frac < DELTA_MAX_FRAC) {
+        const k = changed.length;
+        const body = new Uint8Array(k * 4 + k * C);
+        const dv = new DataView(body.buffer);
+        for (let j = 0; j < k; j++) dv.setUint32(j * 4, changed[j], true); // LE indices
+        let off = k * 4;
+        for (let j = 0; j < k; j++) { const o = changed[j] * C; for (let c = 0; c < C; c++) body[off++] = raw[o + c]; }
+        candidates.push({ tag: TAG_DELTA, payload: deflate(body) });
+      }
+      if (frac >= ZLIB_MIN_FRAC || candidates.length === 0) {
+        const z = deflate(raw);
+        if (z.length < raw.length) candidates.push({ tag: TAG_ZLIB, payload: z });
+        else candidates.push({ tag: TAG_RAW, payload: raw });
+      }
+
+      let best = candidates[0];
+      for (const cnd of candidates) if (cnd.payload.length < best.payload.length) best = cnd;
+      let tag = best.tag, payload = best.payload;
+      if (raw.length < payload.length) { tag = TAG_RAW; payload = raw; } // never exceed raw
+
+      const msg = concat([msgHeader(frameIndex, tag), payload]);
+      prev = raw.slice(); // lossless: what the client shows equals the true frame
+      return { msg, shown: prev };
+    }
+
+    return { encode, reset() { prev = null; index = 0; } };
+  }
+
+  function encodeFramesToAscf(frames, meta, opts) {
+    const cellBytes = meta.cellBytes != null ? meta.cellBytes : (meta.pixel ? 3 : 4);
+    const mode = meta.mode != null ? meta.mode : 5;
+    const enc = makeEncoder(cellBytes, opts);
+    const parts = [ascfHeader(meta.fps, mode, cellBytes === 3, meta.cols, meta.rows)];
+    for (const f of frames) {
+      const { msg } = enc.encode(f);
+      const lp = new Uint8Array(4);
+      new DataView(lp.buffer).setUint32(0, msg.length, false); // big-endian length
+      parts.push(lp, msg);
+    }
+    return concat(parts);
+  }
+
+  return { makeEncoder, ascfHeader, encodeFramesToAscf, concat,
+           TAG_RAW, TAG_ZLIB, TAG_DELTA, KEYFRAME_INTERVAL };
+});

--- a/static_player/studio/index.html
+++ b/static_player/studio/index.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ASCILINE Studio - compile & play</title>
+<style>
+  :root{
+    color-scheme:light;
+    --bg:#f4f2ec; --ink:#23281f; --muted:#6b7261; --panel:#fffffd;
+    --line:#e2e1d3; --line-strong:#cdccba;
+    --sage:#5f8a5f; --forest:#2f4a2f; --accent:#3f7d4f; --accent-ink:#fff;
+    --accent-primary:#3f7d4f;
+    --stage:#0f120e; --stage-ink:#8fe0a0;
+    --danger:#b23b2e; --radius:12px;
+    --mono:"Courier New",ui-monospace,Menlo,Consolas,monospace;
+    --sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;
+    -webkit-font-smoothing:antialiased}
+  a{color:var(--accent)}
+  .wrap{max-width:1080px;margin:0 auto;padding:28px 20px 64px}
+
+  header.top{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;margin-bottom:6px}
+  h1.word{font-family:var(--mono);font-weight:700;letter-spacing:3px;font-size:20px;color:var(--forest);margin:0}
+  .word b{color:var(--sage)}
+  .tag{font-family:var(--mono);font-size:12px;color:var(--muted);letter-spacing:1px}
+  .lede{color:var(--muted);max-width:70ch;margin:2px 0 26px;font-size:15px}
+  .lede code{font-family:var(--mono);background:#eceadf;border:1px solid var(--line);border-radius:5px;padding:1px 6px;font-size:.9em}
+
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  @media(max-width:820px){.grid{grid-template-columns:1fr}}
+
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);
+    padding:18px 18px 20px;display:flex;flex-direction:column;gap:14px}
+  .card h2{margin:0;font-family:var(--mono);font-size:13px;letter-spacing:2px;color:var(--forest);
+    text-transform:uppercase;display:flex;align-items:center;gap:8px}
+  .card h2 .n{display:inline-flex;width:20px;height:20px;border:1px solid var(--sage);border-radius:50%;
+    align-items:center;justify-content:center;font-size:11px;color:var(--sage)}
+
+  .drop{border:1.5px dashed var(--line-strong);border-radius:10px;padding:26px 16px;text-align:center;
+    cursor:pointer;transition:border-color .15s,background .15s;color:var(--muted);background:#faf9f3}
+  .drop:hover{border-color:var(--sage);background:#f3f6ef}
+  .drop.over{border-color:var(--accent);background:#eef5ec;color:var(--forest)}
+  .drop .big{font-family:var(--mono);color:var(--ink);font-size:14px;letter-spacing:.5px}
+  .drop .sub{font-size:12px;margin-top:6px}
+  .drop.has{border-style:solid;border-color:var(--sage);background:#f2f6ef;color:var(--forest)}
+
+  .opts{display:flex;gap:12px;flex-wrap:wrap;align-items:flex-end}
+  .field{display:flex;flex-direction:column;gap:4px}
+  .field label{font-family:var(--mono);font-size:11px;letter-spacing:1px;color:var(--muted);text-transform:uppercase}
+  .field input{width:96px;font-family:var(--mono);font-size:14px;padding:7px 9px;border:1px solid var(--line-strong);
+    border-radius:7px;background:#fffdf9;color:var(--ink)}
+  .field input:focus{border-color:var(--accent)}
+  .hint{font-size:11px;color:var(--muted)}
+
+  button.btn{font-family:var(--mono);font-size:13px;letter-spacing:2px;text-transform:uppercase;
+    padding:11px 16px;border-radius:8px;border:1px solid var(--accent);background:transparent;color:var(--accent);
+    cursor:pointer;transition:background .15s,color .15s}
+  button.btn:hover:not(:disabled){background:var(--accent);color:var(--accent-ink)}
+  button.btn.solid{background:var(--accent);color:var(--accent-ink)}
+  button.btn:disabled{opacity:.4;cursor:default;border-color:var(--line-strong);color:var(--muted)}
+  .row{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+
+  .bar{height:8px;border-radius:6px;background:#e7e6da;overflow:hidden;border:1px solid var(--line)}
+  .bar > i{display:block;height:100%;width:0;background:var(--accent);transition:width .1s}
+  .status{font-family:var(--mono);font-size:12px;color:var(--muted);min-height:16px}
+  .status.err{color:var(--danger)}
+
+  /* Player stage (reader.js container) */
+  .stage-card{margin-top:20px}
+  #stage{position:relative;width:100%;background:var(--stage);border:1px solid var(--line-strong);
+    border-radius:10px;overflow:hidden;min-height:220px}
+  #stage .ascii-canvas{display:none}
+  #stage .ascii-player{display:none;white-space:pre;font-family:var(--mono);font-weight:700;color:var(--stage-ink);margin:0}
+  #stage .status{position:absolute;top:8px;left:12px;z-index:6;color:var(--stage-ink);
+    background:rgba(0,0,0,.35);padding:2px 8px;border-radius:5px}
+  .play-overlay{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;
+    gap:10px;z-index:8;color:var(--stage-ink);cursor:pointer}
+  .play-overlay.hidden{display:none}
+  .play-overlay .disc{width:64px;height:64px;border:2px solid var(--stage-ink);border-radius:50%;
+    display:flex;align-items:center;justify-content:center;font-size:22px}
+  .play-overlay .t{font-family:var(--mono);font-size:12px;letter-spacing:1px;opacity:.85}
+  .stage-hint{font-size:11px;color:var(--muted);margin-top:8px;font-family:var(--mono)}
+  .foot{margin-top:26px;font-size:12px;color:var(--muted);border-top:1px solid var(--line);padding-top:14px}
+  .foot code{font-family:var(--mono)}
+
+  a:focus-visible,button:focus-visible,input:focus-visible,[role="button"]:focus-visible{
+    outline:2px solid var(--accent);outline-offset:2px;border-radius:6px}
+  @media (prefers-reduced-motion: reduce){
+    *,*::before,*::after{transition-duration:1ms!important;animation-duration:1ms!important;scroll-behavior:auto!important}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="top">
+    <h1 class="word">ASCILINE<b> STUDIO</b></h1>
+    <span class="tag">COMPILE &amp; PLAY &middot; STATIC &middot; NO BACKEND</span>
+  </header>
+  <p class="lede">
+    Turn a video into a compiled <code>.ascf</code> entirely in your browser, then play it back.
+    No server, no upload: the file never leaves your machine. Compiling uses the same
+    <code>codec.js</code> wire format the player reads, so the output runs anywhere ASCILINE runs.
+    Pixel mode (color). Audio and ASCII character modes come from the Python <code>compiler.py</code>.
+  </p>
+
+  <div class="grid">
+    <!-- COMPILE -->
+    <section class="card">
+      <h2><span class="n">1</span> Compile a video</h2>
+      <div id="dropVid" class="drop" role="button" tabindex="0" aria-label="Choose or drop a video file to compile to .ascf">
+        <div class="big">Drop a video here</div>
+        <div class="sub">or click to choose &middot; mp4, webm, mov &middot; stays local</div>
+      </div>
+      <input id="fileVid" type="file" accept="video/*" hidden>
+      <div class="opts">
+        <div class="field"><label for="cols">Columns</label><input id="cols" type="number" min="16" max="640" step="2" value="200"></div>
+        <div class="field"><label for="fps">FPS</label><input id="fps" type="number" min="1" max="30" step="1" value="24"></div>
+        <div class="field" style="flex:1;min-width:120px;justify-content:flex-end">
+          <span class="hint">Higher columns = sharper but heavier. Rows auto from aspect.</span>
+        </div>
+      </div>
+      <div class="row">
+        <button id="btnCompile" class="btn solid" disabled>Compile to .ascf</button>
+        <a id="dl" class="btn" style="display:none;text-decoration:none" download>Download .ascf</a>
+      </div>
+      <div class="bar"><i id="prog"></i></div>
+      <div id="stCompile" class="status" role="status" aria-live="polite">Waiting for a video.</div>
+    </section>
+
+    <!-- PLAY -->
+    <section class="card">
+      <h2><span class="n">2</span> Play a .ascf</h2>
+      <div id="dropAscf" class="drop" role="button" tabindex="0" aria-label="Choose or drop a .ascf file, plus an optional .mp3, to play">
+        <div class="big">Drop a .ascf here</div>
+        <div class="sub">or click to choose &middot; add a .mp3 to play sound</div>
+      </div>
+      <input id="fileAscf" type="file" accept=".ascf,.mp3,audio/mpeg" multiple hidden>
+      <div class="status" id="stPlay" role="status" aria-live="polite">A compiled clip auto-loads below. Or drop your own.</div>
+      <div class="hint">Click the stage or press <b>Space</b> to pause. Loops by default.</div>
+    </section>
+  </div>
+
+  <!-- SHARED PLAYER STAGE -->
+  <section class="card stage-card">
+    <h2>Player</h2>
+    <div id="stage">
+      <div class="status" aria-live="polite"></div>
+      <pre class="ascii-player"></pre>
+      <canvas class="ascii-canvas"></canvas>
+      <audio class="ascii-audio" preload="none"></audio>
+      <div class="play-overlay">
+        <div class="disc">&#9654;</div>
+        <div class="t">Compile a video or drop a .ascf</div>
+      </div>
+    </div>
+    <div class="stage-hint">Renders on a canvas, so it keeps animating where a muted &lt;video autoplay&gt; would be blocked (e.g. iOS Low Power Mode).</div>
+  </section>
+
+  <div class="foot">
+    Built on ASCILINE's own <code>codec.js</code> and <code>reader.js</code>. The compiler emits only
+    codec tags 0/1/2 (RAW/ZLIB/DELTA), which the shipped decoder supports. Everything runs client-side.
+  </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js"></script>
+<script src="../../codec.js"></script>
+<script src="../reader.js"></script>
+<script src="./encoder.js"></script>
+<script>
+(function(){
+  var stage = document.getElementById('stage');
+  var player = new AscilinePlayer(stage, { loop:true });
+
+  var lastUrl = null, lastAudioUrl = null;
+  function loadIntoPlayer(url, audioUrl){
+    try { player.stop(); } catch(e){}
+    if (lastUrl && lastUrl.startsWith('blob:')) { /* keep for download; revoked elsewhere */ }
+    setTimeout(function(){ player.play(url, audioUrl || null); }, 30);
+  }
+
+  function clamp(v,a,b){ v = parseInt(v)||0; return Math.max(a, Math.min(b, v)); }
+  function seek(video,t){ return new Promise(function(res){ function h(){ video.removeEventListener('seeked',h); res(); } video.addEventListener('seeked',h); try{ video.currentTime = t; }catch(e){ res(); } }); }
+
+  // ---- Compile pipeline (video -> BGR frames -> .ascf) ----
+  var vidFile = null;
+  var dropVid = document.getElementById('dropVid');
+  var fileVid = document.getElementById('fileVid');
+  var btnCompile = document.getElementById('btnCompile');
+  var prog = document.getElementById('prog');
+  var stCompile = document.getElementById('stCompile');
+  var dl = document.getElementById('dl');
+
+  function setStatus(el, msg, err){ el.textContent = msg; el.className = 'status' + (err ? ' err' : ''); }
+
+  function pickVideo(f){
+    if (!f) return;
+    vidFile = f;
+    dropVid.classList.add('has');
+    dropVid.querySelector('.big').textContent = f.name;
+    dropVid.querySelector('.sub').textContent = (f.size/1048576).toFixed(1) + ' MB - ready to compile';
+    btnCompile.disabled = false;
+    setStatus(stCompile, 'Ready. Click "Compile to .ascf".');
+    dl.style.display = 'none';
+  }
+
+  async function compile(){
+    if (!vidFile) return;
+    btnCompile.disabled = true; dl.style.display = 'none'; prog.style.width = '0';
+    var cols = clamp(document.getElementById('cols').value, 16, 640);
+    var targetFps = clamp(document.getElementById('fps').value, 1, 30);
+
+    var url = URL.createObjectURL(vidFile);
+    var video = document.createElement('video');
+    video.muted = true; video.playsInline = true; video.preload = 'auto'; video.src = url;
+    try {
+      await new Promise(function(res,rej){ video.onloadedmetadata = res; video.onerror = function(){ rej(new Error('cannot read this video')); }; });
+    } catch(e){ setStatus(stCompile, e.message, true); URL.revokeObjectURL(url); btnCompile.disabled=false; return; }
+
+    var vw = video.videoWidth, vh = video.videoHeight, dur = video.duration;
+    if (!isFinite(dur) || dur <= 0){ setStatus(stCompile, 'video has no finite duration', true); URL.revokeObjectURL(url); btnCompile.disabled=false; return; }
+    var ratio = vw / Math.max(vh,1);
+    var rows = Math.max(1, Math.round(cols / ratio));   // pixel-mode rows
+    var fps = Math.min(targetFps, 30);
+    var total = Math.max(1, Math.floor(dur * fps));
+
+    var cvs = document.createElement('canvas'); cvs.width = cols; cvs.height = rows;
+    var cx = cvs.getContext('2d', { willReadFrequently:true });
+    var bgr = new Uint8Array(cols*rows*3);
+
+    var enc = AscilineEncoder.makeEncoder(3);
+    var parts = [ AscilineEncoder.ascfHeader(fps, 5, true, cols, rows) ];
+    var bytes = 14;
+    var t0 = performance.now();
+
+    for (var i=0; i<total; i++){
+      var t = Math.min(dur - 1e-3, i / fps);
+      await seek(video, t);
+      cx.drawImage(video, 0, 0, cols, rows);
+      var img = cx.getImageData(0, 0, cols, rows).data;      // RGBA
+      for (var p=0,q=0; p<img.length; p+=4,q+=3){ bgr[q]=img[p+2]; bgr[q+1]=img[p+1]; bgr[q+2]=img[p]; } // -> BGR
+      var out = enc.encode(bgr).msg;
+      var lp = new Uint8Array(4); new DataView(lp.buffer).setUint32(0, out.length, false);
+      parts.push(lp, out); bytes += 4 + out.length;
+      if (i % 3 === 0 || i === total-1){
+        prog.style.width = ((i+1)/total*100).toFixed(1) + '%';
+        setStatus(stCompile, 'Compiling ' + (i+1) + '/' + total + ' frames - ' + (bytes/1048576).toFixed(2) + ' MB');
+      }
+    }
+    URL.revokeObjectURL(url);
+
+    var ascf = AscilineEncoder.concat(parts);
+    var blob = new Blob([ascf], { type:'application/octet-stream' });
+    var outUrl = URL.createObjectURL(blob);
+    var name = (vidFile.name.replace(/\.[^.]+$/, '') || 'out') + '.ascf';
+    dl.href = outUrl; dl.download = name; dl.style.display = '';
+    dl.textContent = 'Download ' + name + ' (' + (ascf.length/1048576).toFixed(2) + ' MB)';
+    var secs = ((performance.now()-t0)/1000).toFixed(1);
+    setStatus(stCompile, 'Done: ' + total + ' frames, ' + cols + 'x' + rows + ' @ ' + fps + ' fps, ' + (ascf.length/1048576).toFixed(2) + ' MB in ' + secs + 's. Playing below.');
+    prog.style.width = '100%';
+    btnCompile.disabled = false;
+    loadIntoPlayer(outUrl, null);
+  }
+
+  btnCompile.addEventListener('click', function(){ compile().catch(function(e){ setStatus(stCompile, 'Error: ' + e.message, true); btnCompile.disabled=false; }); });
+
+  // ---- Play existing .ascf (+ optional .mp3) ----
+  var dropAscf = document.getElementById('dropAscf');
+  var fileAscf = document.getElementById('fileAscf');
+  var stPlay = document.getElementById('stPlay');
+
+  function pickAscf(list){
+    var ascf=null, mp3=null;
+    for (var i=0;i<list.length;i++){
+      var f = list[i]; var n = (f.name||'').toLowerCase();
+      if (n.endsWith('.ascf')) ascf = f;
+      else if (n.endsWith('.mp3') || f.type==='audio/mpeg') mp3 = f;
+    }
+    if (!ascf){ setStatus(stPlay, 'Please include a .ascf file.', true); return; }
+    dropAscf.classList.add('has');
+    dropAscf.querySelector('.big').textContent = ascf.name;
+    dropAscf.querySelector('.sub').textContent = mp3 ? ('+ ' + mp3.name) : 'no audio';
+    var aUrl = URL.createObjectURL(ascf);
+    var mUrl = mp3 ? URL.createObjectURL(mp3) : null;
+    setStatus(stPlay, 'Playing ' + ascf.name + (mp3 ? ' with audio' : '') + '.');
+    loadIntoPlayer(aUrl, mUrl);
+  }
+
+  // ---- Drop-zone wiring ----
+  function wireDrop(zone, input, onFiles){
+    zone.addEventListener('click', function(){ input.click(); });
+    zone.addEventListener('keydown', function(e){ if(e.key==='Enter'||e.key===' '||e.code==='Space'){ e.preventDefault(); e.stopPropagation(); input.click(); } });
+    input.addEventListener('change', function(){ if (input.files && input.files.length) onFiles(input.files); });
+    ['dragenter','dragover'].forEach(function(ev){ zone.addEventListener(ev, function(e){ e.preventDefault(); zone.classList.add('over'); }); });
+    ['dragleave','dragend','drop'].forEach(function(ev){ zone.addEventListener(ev, function(e){ e.preventDefault(); zone.classList.remove('over'); }); });
+    zone.addEventListener('drop', function(e){ if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length) onFiles(e.dataTransfer.files); });
+  }
+  wireDrop(dropVid, fileVid, function(files){ pickVideo(files[0]); });
+  wireDrop(dropAscf, fileAscf, function(files){ pickAscf(files); });
+
+  // whole-window drag guard so a stray drop doesn't navigate away
+  ['dragover','drop'].forEach(function(ev){ window.addEventListener(ev, function(e){ e.preventDefault(); }); });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What this adds

A single static page under `static_player/studio/` that compiles a video to `.ascf` and plays it back, entirely in the browser. No server and no upload: the file stays on the user's machine. It is built on the existing `codec.js` and `reader.js`, so it reuses the shipped, tested path instead of adding a parallel one.

**Live preview:** https://wondrous-speculoos-4426e1.netlify.app  (drop a short video, it compiles and plays below)

## Why

The current `static_player/index.html` asks the user to type a filename by hand. This gives the static path a real drag-and-drop front end for both halves (compiler and player), in the spirit of #19.

## How it works

- **Player:** drop a `.ascf` (and an optional `.mp3`) on the zone; it plays through `AscilinePlayer` from `reader.js`, unchanged.
- **Compiler:** drop a video. A hidden `<video>` decodes it, each frame is drawn to a `cols x rows` canvas, converted to BGR, and encoded to `.ascf` by a small JS port of `codec.py` (`encoder.js`). The result is offered as a download and auto-plays.
- The encoder emits only codec tags 0 (RAW), 1 (ZLIB) and 2 (DELTA), which `codec.js` decodes. Output is lossless with a keyframe every 48 frames. Verified bit-exact against `codec.js`: encode then decode returns the source pixels.

## Scope and constraints

- Pixel mode (color). Audio extraction and the ASCII character modes stay in the Python `compiler.py`; the page states this.
- Additive and opt-in. The live WebSocket path and existing files are untouched.
- No build step. Only `pako` is loaded from a CDN, as in the current `index.html`.

## One heads-up (can be a separate PR)

While matching the wire format I noticed `codec.py`'s `_full_frame` can return tag 3 (`TAG_RLE_FULL`), but the shipped `codec.js` handles only tags 0/1/2 and throws on tag 3 ("Unknown ASCILINE codec tag: 3"). So a `.ascf` whose keyframe the Python compiler encodes as RLE_FULL would fail to play in the current player. This Studio's encoder avoids the issue by never emitting tag 3. Happy to add a short tag-3 branch to `codec.js` in a separate PR if useful.

## Files

- `static_player/studio/index.html` - the studio page (drop zones, options, shared player)
- `static_player/studio/encoder.js` - client-side `.ascf` encoder (tags 0/1/2)
- reuses `codec.js` and `static_player/reader.js` as-is
