### PR TITLE
feat: refine mode quantization and fix pixel command UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -367,7 +367,7 @@ function renderFrame(now) {
         currentFps = frameCount;
         frameCount = 0;
         lastFpsUpdate = now;
-        const modes = { 2: '512 Color', 3: '32K Color', 4: '262K Color', 5: '16M Ultra' };
+        const modes = { 2: '64 Color', 3: '512 Color', 4: '32K Color', 5: '262K Color', 6: '16M Ultra' };
         const label = (modes[renderMode] || 'B&W') + (pixelMode ? ' PIXEL' : '');
         statusEl.textContent = `FPS: ${currentFps}/${Math.round(targetFps)} | Buf: ${frameBuffer.length} | ${label}`;
     }

--- a/static_player/compiler.py
+++ b/static_player/compiler.py
@@ -96,7 +96,7 @@ def compile_video(args):
     print(f"[Compiler] Dimensions: {cols}x{rows} | Mode: {render_mode} | Pixel: {pixel_mode} | FPS: {effective_fps:.1f}")
 
     char_byte_lut = np.array([ord(c) for c in mapper._lut], dtype=np.uint8)
-    qb = {5: 0, 4: 2, 3: 3, 2: 5}.get(render_mode, 0)
+    qb = {6: 0, 5: 2, 4: 3, 3: 5, 2: 6}.get(render_mode, 0)
     
     frame_buf = np.empty((rows, cols, 4), dtype=np.uint8) if render_mode > 1 else None
 
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     parser.add_argument("video", help="Path to input video")
     parser.add_argument("--cols", type=int, default=300, help="Grid columns (default 300)")
     parser.add_argument("--rows", type=int, default=0, help="Grid rows (0 = auto)")
-    parser.add_argument("--mode", type=int, default=5, choices=[1, 2, 3, 4, 5], help="Render mode")
+    parser.add_argument("--mode", type=int, default=6, choices=[1, 2, 3, 4, 5, 6], help="Render mode: 1=B&W  2=64c  3=512c  4=32Kc  5=262Kc  6=16M Ultra")
     parser.add_argument("--pixel", action="store_true", help="Pixel mode (no characters)")
     parser.add_argument("--tolerance", type=int, default=0, help="Color drift tolerance (0=lossless)")
     parser.add_argument("--hard", action="store_true", help="Use maximum zlib compression (level 9) instead of default (level 3). Slower but smaller file.")

--- a/static_player/reader.js
+++ b/static_player/reader.js
@@ -354,7 +354,7 @@ class AscilinePlayer {
             this.currentFps = this.frameCount;
             this.frameCount = 0;
             this.lastFpsUpdate = now;
-            const modes = { 2: '512 Color', 3: '32K Color', 4: '262K Color', 5: '16M Ultra' };
+            const modes = { 2: '64 Color', 3: '512 Color', 4: '32K Color', 5: '262K Color', 6: '16M Ultra' };
             const label = (modes[this.renderMode] || 'B&W') + (this.pixelMode ? ' PIXEL' : '');
             if (this.statusEl) {
                 this.statusEl.textContent = `FPS: ${this.currentFps}/${Math.round(this.targetFps)} | Buf: ${this.frameBuffer.length} | ${label}`;

--- a/stream_server.py
+++ b/stream_server.py
@@ -641,7 +641,7 @@ async def websocket_endpoint(websocket: WebSocket):
             sharpness_kernel  = None
             filter_palette    = "default"
             gray_lut          = None  # None = identity (skip cv2.LUT call)
-            qb           = {5: 0, 4: 2, 3: 3, 2: 5}.get(render_mode, 0)
+            qb           = {6: 0, 5: 2, 4: 3, 3: 5, 2: 6}.get(render_mode, 0)
 
             # ── FPS DECIMATION ──
             # If source > 30 FPS, skip every Nth frame using grab() (no decode).
@@ -973,9 +973,9 @@ HELP_TEXT = "\033[1;37m" + """
 ║  \033[32m--folder\033[1;37m       Play all videos in a folder      ║
 ║                                                   ║
 ║  \033[33m─── Render ───\033[1;37m                                  ║
-║  \033[32m--mode\033[1;37m  \033[35m1-5\033[1;37m    Color quality                    ║
-║     1=B&W  2=512c  3=32Kc  4=262Kc  5=16M        ║
-║  \033[32m--pixel\033[1;37m        Pixel block mode (with mode 2-5) ║
+║  \033[32m--mode\033[1;37m  \033[35m1-6\033[1;37m    Color quality                    ║
+║     1=B&W  2=64c  3=512c  4=32Kc  5=262Kc  6=16M  ║
+║  \033[32m--pixel\033[1;37m        Pixel block mode                 ║
 ║  \033[32m--cols\033[1;37m  \033[35mN\033[1;37m      Grid columns  (default: 200)     ║
 ║  \033[32m--rows\033[1;37m  \033[35mN\033[1;37m      Grid rows     (default: auto)    ║
 ║                                                   ║
@@ -1080,13 +1080,13 @@ if __name__ == "__main__":
     render = parser.add_argument_group('\033[33mRender\033[0m')
     render.add_argument(
         "--mode",
-        type=int, choices=[1, 2, 3, 4, 5], default=1,
-        help="Color quality: 1=B&W  2=512c  3=32Kc  4=262Kc  5=16M Ultra"
+        type=int, choices=[1, 2, 3, 4, 5, 6], default=1,
+        help="Color quality: 1=B&W  2=64c  3=512c  4=32Kc  5=262Kc  6=16M Ultra"
     )
     render.add_argument(
         "--pixel",
         action="store_true", default=False,
-        help="Pixel mode: replaces ASCII characters with colored blocks (combine with --mode 2-5)"
+        help="Pixel mode: replaces ASCII characters with colored blocks"
     )
     render.add_argument("--cols", type=int, default=None, help="Grid columns (default: 200 for text, 450 for pixel)")
     render.add_argument("--rows", type=int, default=0,   help="Grid rows    (default: auto from video aspect ratio)")
@@ -1122,10 +1122,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # Validate: --pixel requires color mode (2-5)
+    # Automatically switch to a color mode if pixel mode is requested,
+    # because the client requires mode > 1 to initialize the Canvas/Binary decoder.
     if args.pixel and args.mode == 1:
-        print("[ERROR] --pixel requires a color mode (--mode 2-5). B&W mode is text-only.")
-        exit(1)
+        args.mode = 6
 
     # Validate: --pixel does not support adaptive codec quality flags
     if args.pixel and args.quality != "lossless":


### PR DESCRIPTION
- Shifted Mode 2 to 64-color (qb=6) for extreme bandwidth savings

- Expanded available color modes to 1-6

- Automatically override to mode 6 when --pixel is passed to avoid UX friction

- Cleaned up confusing help text regarding pixel mode combinations