### PR TITLE
Fix: keep the profile vectors in the standard vectors/<name>/ layout

### DIFF
--- a/experiments/check_profile.js
+++ b/experiments/check_profile.js
@@ -1,26 +1,40 @@
-// Decode the lossy-DCT-profile (tag 4) vectors with the shipped codec.js and assert
-// bit-exact against the codec.py encoder. Mirrors check_vectors.js.
-const fs = require('fs'), path = require('path'), crypto = require('crypto');
-const Codec = require(path.join(__dirname, '..', 'codec.js'));
-const sha = u => crypto.createHash('sha256').update(Buffer.from(u)).digest('hex');
-(async () => {
-  const d = path.join(__dirname, 'vectors');
-  const meta = JSON.parse(fs.readFileSync(path.join(d, 'profile_meta.json')));
-  const buf = new Uint8Array(fs.readFileSync(path.join(d, 'profile.bin')));
-  const dv = new DataView(buf.buffer); const msgs = []; let off = 0;
-  while (off + 4 <= buf.length) { const len = dv.getUint32(off, false); off += 4; msgs.push(buf.subarray(off, off + len)); off += len; }
+/**
+ * Profile-specific checks for the lossy DCT profile (tag 4). The vectors live in the
+ * standard experiments/vectors/ layout, so check_vectors.js already proves them
+ * bit-exact; this script adds the one invariant a plain vector check cannot express.
+ */
+const fs = require('fs');
+const path = require('path');
+const codec = require('../codec.js');
+const dir = path.join(__dirname, 'vectors', 'profile_qf70');
 
-  const dec = Codec.makeDecoder(3); const shas = [];
-  for (const m of msgs) shas.push(sha((await dec.decode(m)).frame));
-  const ok = shas.length === meta.frame_shas.length && shas.every((s, i) => s === meta.frame_shas[i]);
-  console.log('profile frames ' + shas.length + '/' + meta.nframes + ' : ' + (ok ? 'BIT-EXACT OK' : 'FAIL'));
+function readChunks(buf) {
+  const out = []; let off = 0;
+  while (off + 4 <= buf.length) { const len = buf.readUInt32BE(off); off += 4;
+    out.push(new Uint8Array(buf.subarray(off, off + len))); off += len; }
+  return out;
+}
+const same = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+(async () => {
+  const meta = JSON.parse(fs.readFileSync(path.join(dir, 'meta.json')));
+  const msgs = readChunks(fs.readFileSync(path.join(dir, 'adaptive.bin')));
+  const truth = readChunks(fs.readFileSync(path.join(dir, 'truth.bin')));
+
+  const dec = codec.makeDecoder(meta.cellBytes);
+  let ok = true;
+  for (let i = 0; i < msgs.length; i++) ok = same((await dec.decode(msgs[i])).frame, truth[i]) && ok;
+  console.log(`profile tag 4        ${String(msgs.length).padStart(3)} frames  ${ok ? 'PASS bit-exact' : 'FAIL'}`);
 
   // The profile decoder reuses module-level scratch across blocks to keep the hot path
   // allocation-free. That is only sound because its block loop never awaits, so two
   // decoders can never interleave inside it. Guard the invariant rather than trust it.
-  const a = Codec.makeDecoder(3), b = Codec.makeDecoder(3); const sa = [], sb = [];
-  for (const m of msgs) { const [ra, rb] = await Promise.all([a.decode(m), b.decode(m)]); sa.push(sha(ra.frame)); sb.push(sha(rb.frame)); }
-  const conc = sa.every((s, i) => s === meta.frame_shas[i]) && sb.every((s, i) => s === meta.frame_shas[i]);
-  console.log('concurrent decoders, shared scratch : ' + (conc ? 'OK' : 'FAIL'));
+  const a = codec.makeDecoder(meta.cellBytes), b = codec.makeDecoder(meta.cellBytes);
+  let conc = true;
+  for (let i = 0; i < msgs.length; i++) {
+    const [ra, rb] = await Promise.all([a.decode(msgs[i]), b.decode(msgs[i])]);
+    conc = same(ra.frame, truth[i]) && same(rb.frame, truth[i]) && conc;
+  }
+  console.log(`concurrent decoders  ${String(msgs.length).padStart(3)} frames  ${conc ? 'PASS shared scratch safe' : 'FAIL'}`);
   process.exit(ok && conc ? 0 : 1);
-})();
+})().catch((e) => { console.error(e); process.exit(2); });

--- a/experiments/profile_vectors.py
+++ b/experiments/profile_vectors.py
@@ -1,21 +1,38 @@
-# Encode lossy-DCT-profile (tag 4) test vectors with codec.py, for cross-language
-# bit-exact verification by check_profile.js. Mirrors gen_vectors.py -> check_vectors.js.
-import os, sys, struct, hashlib, json, math
+# Encode lossy-DCT-profile (tag 4) test vectors with codec.py, using the same output
+# layout as gen_vectors.py (experiments/vectors/<name>/ with meta.json, adaptive.bin
+# and truth.bin) so check_vectors.js verifies the profile alongside the other vectors.
+import os, sys, struct, json, math
 import numpy as np
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from codec import ProfileEncoder
+
 W, H, N, QF = 160, 96, 40, 70
+NAME = "profile_qf70"
+
 def frame(i):
     yy, xx = np.mgrid[0:H, 0:W]
     B=(40+180*xx/W).astype(np.uint8); G=(30+150*yy/H).astype(np.uint8); R=np.full((H,W),60,np.uint8)
     bx=int((0.5+0.4*math.sin(i/N*2*math.pi))*(W-24)); by=int((0.5+0.4*math.cos(i/N*2*math.pi))*(H-24))
     R[by:by+24,bx:bx+24]=230; G[by:by+24,bx:bx+24]=230; B[by:by+24,bx:bx+24]=80
     return np.ascontiguousarray(np.stack([B,G,R],2).astype(np.uint8))
-d = os.path.join(os.path.dirname(__file__), "vectors"); os.makedirs(d, exist_ok=True)
-enc = ProfileEncoder(W, H, QF); msgs = bytearray(); shas = []
+
+outdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vectors", NAME)
+os.makedirs(outdir, exist_ok=True)
+enc = ProfileEncoder(W, H, QF)
+fa = open(os.path.join(outdir, "adaptive.bin"), "wb")
+ft = open(os.path.join(outdir, "truth.bin"), "wb")
+raw_total = adapt_total = 0
 for i in range(N):
-    m, shown = enc.encode(frame(i)); msgs += struct.pack(">I", len(m)) + m
-    shas.append(hashlib.sha256(shown).hexdigest())
-open(os.path.join(d, "profile.bin"), "wb").write(bytes(msgs))
-json.dump({"W":W,"H":H,"QF":QF,"nframes":N,"frame_shas":shas}, open(os.path.join(d,"profile_meta.json"),"w"))
-print("wrote profile vectors: %d frames %dx%d QF%d, %.1f KB" % (N, W, H, QF, len(msgs)/1024))
+    msg, shown = enc.encode(frame(i))
+    # Truth = the encoder's intended frame, i.e. the lossy approximation the client
+    # must reconstruct exactly, same convention as the tolerance vectors.
+    body = bytes(shown)
+    fa.write(struct.pack(">I", len(msg))); fa.write(msg)
+    ft.write(struct.pack(">I", len(body))); ft.write(body)
+    raw_total += 4 + len(body); adapt_total += len(msg)
+fa.close(); ft.close()
+json.dump({"cellBytes": 3, "nframes": N, "rows": H, "cols": W,
+           "legacyBytes": raw_total, "adaptiveBytes": adapt_total},
+          open(os.path.join(outdir, "meta.json"), "w"))
+print(f"{NAME:28} {N} frames  legacy={raw_total/1024:7.0f}KB  "
+      f"profile={adapt_total/1024:6.0f}KB ({adapt_total/raw_total:5.1%})")


### PR DESCRIPTION
Sorry about the crash, that one was mine.

`profile_vectors.py` wrote `profile.bin` and `profile_meta.json` flat into `experiments/vectors/`, and `check_vectors.js` treats every entry there as a vector directory, so it went looking for `vectors/profile.bin/meta.json`. I reproduced it before touching anything.

The generator now writes `experiments/vectors/profile_qf70/` with `meta.json`, `adaptive.bin` and `truth.bin`, the same layout `gen_vectors.py` produces. So `check_vectors.js` stops crashing, and it now covers the profile as a normal vector, since truth is the encoder's lossy approximation exactly like your tolerance vectors:

```
fake_legacy_pixel      8 frames  PASS bit-exact   wire 100.0% of legacy
profile_qf70          40 frames  PASS bit-exact   wire 1.2% of legacy

ALL VECTORS BIT-EXACT
```

(the legacy line is a throwaway vector I generated locally to check they cohabit, it is not in the diff)

`check_profile.js` reads that same directory now and keeps only what a plain vector check cannot express: two decoders driven concurrently, which guards the module-level scratch the allocation-free hot path relies on.
