### PR TITLE
build: add pyproject.toml with optional yt-dlp extra (#49)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "asciline"
+version = "0.1.0"
+description = "A high-performance, cross-platform real-time ASCII video rendering engine."
+requires-python = ">=3.9"
+authors = [
+    { name = "YusufB5" }
+]
+dependencies = [
+    "fastapi>=0.100.0",
+    "uvicorn>=0.20.0",
+    "opencv-python>=4.8.0",
+    "numpy>=1.24.0",
+    "websockets>=12.0",
+]
+
+[project.optional-dependencies]
+ytdlp = [
+    "yt-dlp>=2026.07.04",
+]
+
+[tool.setuptools]
+py-modules = [
+    "ascii_video_player2",
+    "codec",
+    "compiler",
+    "logo",
+    "stream_server",
+    "ytdl",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+# Core dependencies. Prefer: pip install -e .
 fastapi>=0.100.0
 uvicorn>=0.20.0
 opencv-python>=4.8.0
 numpy>=1.24.0
 websockets>=12.0
 yt-dlp>=2026.07.04
-


### PR DESCRIPTION
Closes #49 

Adds a PEP 621 `pyproject.toml` with project metadata and core runtime dependencies.
Moves `yt-dlp` into the optional `ytdlp` extra, as requested.

Validated:

```bash
python -m pip install -e .
python -m pip install -e ".[ytdlp]"
python stream_server.py --help
```