### PR TITLE
feat: toast on connection lost; close WS cleanly after queue ends

### DIFF
--- a/app.js
+++ b/app.js
@@ -368,9 +368,13 @@ function connectWebSocket() {
 
     ws.onopen = () => { statusEl.textContent = 'Buffering...'; };
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
         if (state === 'PLAYING' || state === 'PAUSED') {
-            statusEl.textContent = 'Stream Ended.';
+            // 1000 = server closed cleanly after finishing the queue. Anything
+            // else (1006 dropped TCP, 1001/1012 server shutdown) is a real drop.
+            const ended = event.code === 1000;
+            if (!ended) showToast('Connection lost.');
+            statusEl.textContent = ended ? 'Stream Ended.' : 'Connection lost.';
             statusEl.style.color = '#888';
             if (audioEl) audioEl.pause();
             setTimeout(() => finishStream(), 800);
@@ -378,6 +382,7 @@ function connectWebSocket() {
     };
 
     ws.onerror = () => {
+        showToast('Connection lost.');
         statusEl.textContent = 'Connection Error!';
         statusEl.style.color = '#ff0000';
         setTimeout(() => finishStream(), 2000);
@@ -519,6 +524,24 @@ function startBufferReports() {
 
 function stopBufferReports() {
     if (bufferReportTimer) { clearInterval(bufferReportTimer); bufferReportTimer = null; }
+}
+
+// Unexpected disconnect toast. Lazy-created; safe to call twice (onerror+onclose).
+let toastHideTimer = null;
+function showToast(msg) {
+    let el = document.getElementById('connection-toast');
+    if (!el) {
+        el = document.createElement('div');
+        el.id = 'connection-toast';
+        el.className = 'toast';
+        el.setAttribute('role', 'status');
+        el.setAttribute('aria-live', 'polite');
+        container.appendChild(el);
+    }
+    el.textContent = msg;
+    el.classList.add('show');
+    clearTimeout(toastHideTimer);
+    toastHideTimer = setTimeout(() => el.classList.remove('show'), 4000);
 }
 
 function finishStream() {

--- a/stream_server.py
+++ b/stream_server.py
@@ -1020,6 +1020,11 @@ async def websocket_endpoint(websocket: WebSocket):
                     print("[DONE] All videos finished.")
                     break
 
+        # Close the handshake explicitly (code 1000). Falling off the end here
+        # drops the socket without a close frame, which reaches the client as
+        # 1006 — indistinguishable from the server dying mid-stream.
+        await websocket.close()
+
     except (WebSocketDisconnect, ConnectionClosed, RuntimeError):
         print("Client disconnected from the stream.")
 

--- a/style.css
+++ b/style.css
@@ -669,3 +669,27 @@ body {
     color: var(--accent-color);
     text-shadow: 0 0 6px rgba(0, 243, 255, 0.5);
 }
+
+/* ── TOAST ──────────────────────────── */
+.toast {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 20;   /* above the play overlay (10), below the filter menu (100) */
+    background: var(--post-bg);
+    border: 1px solid #333;
+    border-left: 3px solid var(--accent-color);
+    color: var(--accent-color);
+    font-family: var(--font-tech);
+    font-size: 12px;
+    letter-spacing: 1px;
+    padding: 10px 18px;
+    border-radius: 3px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+.toast.show {
+    opacity: 1;
+}

--- a/test/test_close_code.js
+++ b/test/test_close_code.js
@@ -1,0 +1,131 @@
+/**
+ * The player can only warn about a lost connection if it can tell a lost
+ * connection apart from a queue that simply finished. Both used to arrive as
+ * close code 1006, because the server returned from the WebSocket endpoint
+ * without ever performing the closing handshake. This proves they now differ:
+ *
+ *   queue finished -> 1000, wasClean (server closes explicitly)
+ *   server killed  -> 1006, not clean (no close frame ever sent)
+ *
+ * Requires: ffmpeg, and a Python with the server deps (fastapi/uvicorn/opencv).
+ *   Override the interpreter with ASCIL_PY (e.g. ASCIL_PY=.venv/bin/python).
+ *
+ * Usage: node test/test_close_code.js
+ */
+const { spawn, execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const net = require('net');
+const path = require('path');
+
+const PY = process.env.ASCIL_PY || 'python3';
+const REPO = path.dirname(__dirname);
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function waitForPort(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tryOnce = () => {
+      const sock = net.connect(port, '127.0.0.1');
+      sock.on('connect', () => { sock.destroy(); resolve(); });
+      sock.on('error', () => {
+        sock.destroy();
+        if (Date.now() > deadline) reject(new Error('server did not start'));
+        else setTimeout(tryOnce, 150);
+      });
+    };
+    tryOnce();
+  });
+}
+
+// stdin must stay OPEN: the server runs an interactive command loop on the main
+// thread (uvicorn is a daemon thread), and EOF on stdin kills it.
+async function startServer(clip, port) {
+  const server = spawn(PY, ['stream_server.py', clip, '--mode', '2', '--vol', '0',
+    '--cols', '80', '--no-thumbnails', '--host', '127.0.0.1', '--port', String(port)],
+    { cwd: REPO, stdio: ['pipe', 'ignore', 'ignore'] });
+  server.on('error', (e) => { throw e; });
+  await waitForPort(port, 15000);
+  return server;
+}
+
+// Resolve with the CloseEvent the browser player would see. onFirstFrame runs
+// once the stream is actually flowing, so a kill lands mid-stream.
+function awaitClose(port, timeoutMs, onFirstFrame) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws?codec=adaptive`);
+    ws.binaryType = 'arraybuffer';
+    const timer = setTimeout(() => {
+      try { ws.close(); } catch (_) {}
+      reject(new Error(`no close event within ${timeoutMs}ms`));
+    }, timeoutMs);
+    let fired = false;
+    ws.onmessage = (ev) => {
+      if (typeof ev.data === 'string' || fired || !onFirstFrame) return;
+      fired = true;
+      onFirstFrame();
+    };
+    ws.onerror = () => {};  // an abrupt drop errors first, then closes
+    ws.onclose = (ev) => {
+      clearTimeout(timer);
+      resolve({ code: ev.code, wasClean: ev.wasClean });
+    };
+  });
+}
+
+(async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ascil-close-'));
+  const shortClip = path.join(tmp, 'short.mp4');
+  const longClip = path.join(tmp, 'long.mp4');
+  let finished = null, killed = null;
+  try {
+    // Frames are paced in real time, so the short clip bounds how long the
+    // finished-queue case takes, and the long one guarantees the kill is mid-stream.
+    for (const [file, duration] of [[shortClip, 2], [longClip, 30]]) {
+      execFileSync('ffmpeg', [
+        '-y', '-f', 'lavfi', '-i', `testsrc=size=160x120:rate=24:duration=${duration}`,
+        '-pix_fmt', 'yuv420p', file,
+      ], { stdio: 'ignore' });
+    }
+
+    const portA = await freePort();
+    finished = await startServer(shortClip, portA);
+    const onQueueEnd = await awaitClose(portA, 30000, null);
+
+    const portB = await freePort();
+    killed = await startServer(longClip, portB);
+    const onKill = await awaitClose(portB, 30000, () => killed.kill('SIGKILL'));
+
+    const checks = [
+      ['finished queue closes cleanly', onQueueEnd.wasClean, `wasClean=${onQueueEnd.wasClean}`],
+      ['finished queue reports code 1000', onQueueEnd.code === 1000, `code=${onQueueEnd.code}`],
+      ['killed server does not look clean', !onKill.wasClean, `wasClean=${onKill.wasClean}`],
+      ['killed server reports code 1006', onKill.code === 1006, `code=${onKill.code}`],
+      ['the two cases are distinguishable', onQueueEnd.code !== onKill.code,
+        `both=${onKill.code}`],
+    ];
+
+    let failed = 0;
+    for (const [name, ok, why] of checks) {
+      console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : '  -> ' + why}`);
+      if (!ok) failed++;
+    }
+    console.log(`\nqueue finished: ${JSON.stringify(onQueueEnd)}  |  ` +
+      `server killed: ${JSON.stringify(onKill)}`);
+    console.log(`${checks.length - failed}/${checks.length} passed`);
+    process.exitCode = failed === 0 ? 0 : 1;
+  } finally {
+    for (const s of [finished, killed]) if (s) s.kill('SIGKILL');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+})().catch((e) => { console.error('ERROR', e); process.exit(2); });


### PR DESCRIPTION
Closes #55 
## Summary

- Show a non-intrusive **Toast** inside the player (`#player-container`) when the WebSocket drops unexpectedly (`Connection lost.`).
- After the playlist/queue finishes, the server now calls `await websocket.close()` so the client gets close code **1000** instead of an abrupt **1006**.
- The client only toasts when `event.code !== 1000`, so a normal stream end no longer looks like a dropped connection.
- Scope: **Toast only** (no reconnect), as agreed on the issue.

## Why the server change

Previously the endpoint returned after the queue with no closing handshake. The browser saw **1006** for both “finished normally” and “server/network died,” so a disconnect Toast could not be correct without this fix. Error paths already used `websocket.close()`; this matches that pattern.

## Test plan

- [ ] Play a short clip to the end → status shows **Stream Ended.**, **no** Toast
- [ ] Play mid-stream, stop the server (Ctrl+C) → Toast **Connection lost.** appears in the player
- [ ] DevTools → Network → Offline mid-playback → same Toast
- [ ] Intentional stop / return to Ready → **no** Toast
- [ ] `ASCIL_PY=.venv/bin/python node test/test_close_code.js` → 5/5 (finished=1000, killed=1006)



<img width="850" height="718" alt="image" src="https://github.com/user-attachments/assets/28629c05-77a4-4819-b4f8-328aab565b85" />
