### PR TITLE
Use parser.error() for pixel/quality validation, add --version flag

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -9,6 +9,7 @@ import sys
 # Import the existing engine components (now in the same directory)
 from ascii_video_player2 import VideoDecoder, AsciiMapper
 from codec import encode_frame, DEFAULT_LEVEL, ProfileEncoder
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
 
 def extract_audio(video_path: str, output_path: str):
     print(f"[Audio] Attempting to extract audio to {output_path}...")
@@ -210,10 +211,20 @@ if __name__ == "__main__":
     print(logo.render_static())
     print("\033[1;37m" + "═"*55 + "\033[0m\n")
 
+    try:
+        __version__ = _pkg_version("asciline")
+    except PackageNotFoundError:
+        __version__ = "unknown"
+
     parser = argparse.ArgumentParser(
         usage="python compiler.py [options] <video>",
         description="\033[1;36mASCILINE Static Compiler\033[0m\n",
         formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=35)
+    )
+    parser.add_argument(
+        "--version", "-v",
+        action="version",
+        version=f"%(prog)s {__version__}"
     )
     # ── Source ──
     src = parser.add_argument_group('\033[33mSource\033[0m')

--- a/stream_server.py
+++ b/stream_server.py
@@ -13,6 +13,8 @@ import sys
 import signal
 import os
 
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+
 # Enable ANSI escape sequences on Windows early so startup messages are colored
 os.system("")
 
@@ -1120,11 +1122,21 @@ if __name__ == "__main__":
     import argparse
     import threading
 
+    try:
+        __version__ = _pkg_version("asciline")
+    except PackageNotFoundError:
+        __version__ = "unknown"
+
     parser = argparse.ArgumentParser(
         usage="python stream_server.py [options] [video]",
         description=f"{ASCII_LOGO}\n\033[1;36mReal-Time ASCII Web Server\033[0m\n"
                     "Stream local videos to your browser with high performance ASCII and Pixel rendering.\n",
         formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=45)
+    )
+    parser.add_argument(
+        "--version", "-v",
+        action="version",
+        version=f"%(prog)s {__version__}"
     )
 
     # ── Source ──
@@ -1206,8 +1218,7 @@ if __name__ == "__main__":
 
     # Validate: --pixel does not support adaptive codec quality flags
     if args.pixel and args.quality != "lossless":
-        print("[ERROR] --pixel mode sends raw data and does not support the adaptive codec. Remove the --quality flag.")
-        exit(1)
+        parser.error("--pixel mode sends raw data and does not support the adaptive codec. Remove the --quality flag.")
 
     # Build the queue
     queue = build_queue(args)


### PR DESCRIPTION
Closes #53

## Changes
- `stream_server.py`: replaced the manual `print()` + `exit(1)` in the
  `--pixel`/`--quality` validation with `parser.error()`, so it gets the
  standard argparse usage line, consistent error formatting, and exit
  code 2 instead of a bare `exit(1)`.
- Added `--version`/`-v` to both `stream_server.py` and `compiler.py`,
  reading the version from installed package metadata via
  `importlib.metadata` (backed by the `version` field in `pyproject.toml`).

## Testing
- `python3 -m pytest test/` — 20/20 passed, no regressions.
- Manually verified:
  - `python3 compiler.py --version` → `compiler.py 0.1.0`
  - `python3 stream_server.py --version` → `stream_server.py 0.1.0`
  - `python3 stream_server.py --pixel --quality high <video>` → prints
    usage line + `parser.error()` message, exits with code 2.