### PR TITLE
feat: show a fetch status toast while YouTube/ytdlp URLs resolve

### DIFF
--- a/app.js
+++ b/app.js
@@ -233,6 +233,9 @@ function connectWebSocket() {
                 return;
             }
             if (event.data.startsWith('INIT:')) {
+                // First INIT means frames are about to flow — drop any
+                // "fetching..." notification the server sent earlier.
+                hideToast();
                 const p = event.data.split(':');
                 targetFps = parseFloat(p[1]);
                 frameInterval = 1000 / targetFps;
@@ -329,7 +332,16 @@ function connectWebSocket() {
                 return;
 
             }
-            
+
+            // STATUS:<CODE>:<human-readable text> — e.g. the server tells us a
+            // YouTube/ytdlp fetch is starting. MUST return here: any string that
+            // falls through below is parsed as a Mode-1 text frame.
+            if (event.data.startsWith('STATUS:')) {
+                const msgStart = event.data.indexOf(':', 7);
+                if (msgStart !== -1) showToast(event.data.slice(msgStart + 1), true);
+                return;
+            }
+
             // Mode 1: Text Frame with Timestamp
             const text = event.data;
             const newlineIdx = text.indexOf('\n');
@@ -531,8 +543,9 @@ function stopBufferReports() {
 }
 
 // Unexpected disconnect toast. Lazy-created; safe to call twice (onerror+onclose).
+// Pass sticky=true to keep it up until hideToast() (e.g. a fetch in progress).
 let toastHideTimer = null;
-function showToast(msg) {
+function showToast(msg, sticky) {
     let el = document.getElementById('connection-toast');
     if (!el) {
         el = document.createElement('div');
@@ -545,7 +558,17 @@ function showToast(msg) {
     el.textContent = msg;
     el.classList.add('show');
     clearTimeout(toastHideTimer);
-    toastHideTimer = setTimeout(() => el.classList.remove('show'), 4000);
+    toastHideTimer = null;
+    if (!sticky) {
+        toastHideTimer = setTimeout(() => el.classList.remove('show'), 4000);
+    }
+}
+
+function hideToast() {
+    clearTimeout(toastHideTimer);
+    toastHideTimer = null;
+    const el = document.getElementById('connection-toast');
+    if (el) el.classList.remove('show');
 }
 
 function finishStream() {

--- a/app.js
+++ b/app.js
@@ -226,6 +226,7 @@ function connectWebSocket() {
     ws.onmessage = (event) => {
         if (typeof event.data === 'string') {
             if (event.data.startsWith('Error:')) {
+                hideToast();  // drop any "fetching..." notice; the fetch failed
                 statusEl.textContent = event.data;
                 statusEl.style.color = '#ff0000';
                 if (ws) ws.close();
@@ -545,6 +546,7 @@ function stopBufferReports() {
 // Unexpected disconnect toast. Lazy-created; safe to call twice (onerror+onclose).
 // Pass sticky=true to keep it up until hideToast() (e.g. a fetch in progress).
 let toastHideTimer = null;
+let toastSticky = false;
 function showToast(msg, sticky) {
     let el = document.getElementById('connection-toast');
     if (!el) {
@@ -557,6 +559,7 @@ function showToast(msg, sticky) {
     }
     el.textContent = msg;
     el.classList.add('show');
+    toastSticky = !!sticky;
     clearTimeout(toastHideTimer);
     toastHideTimer = null;
     if (!sticky) {
@@ -567,13 +570,21 @@ function showToast(msg, sticky) {
 function hideToast() {
     clearTimeout(toastHideTimer);
     toastHideTimer = null;
+    toastSticky = false;
     const el = document.getElementById('connection-toast');
     if (el) el.classList.remove('show');
+}
+
+// Clear only a sticky (fetch-in-progress) toast — leaves a transient
+// "Connection lost." toast to run out its own timer.
+function hideStickyToast() {
+    if (toastSticky) hideToast();
 }
 
 function finishStream() {
     state = 'IDLE';
     stopBufferReports();
+    hideStickyToast();  // a fetch notice must never outlive the stream
     if (ws) { ws.onclose = null; ws.close(); ws = null; }
     if (audioEl) { audioEl.pause(); audioEl.src = ''; }
     ctx.clearRect(0, 0, canvas.width, canvas.height);

--- a/stream_server.py
+++ b/stream_server.py
@@ -636,6 +636,10 @@ async def websocket_endpoint(websocket: WebSocket):
             # instead of re-downloading.
             if isinstance(video_path, str) and ytdl.is_url(video_path):
                 print(f"[YT] fetching ({queue_index + 1}/{len(queue)}) {video_path}")
+                # Only URL entries reach here; a resolved/cached local path is
+                # written back to entry["video"] above, so the client only sees
+                # this when a download/normalize actually has to run.
+                await websocket.send_text("STATUS:FETCHING_YT:Fetching YouTube stream...")
                 try:
                     video_path = await safe_resolve_video_path(video_path)
                     entry["video"] = video_path


### PR DESCRIPTION
## Deviation (§2)

`STATUS:FETCHING_YT` is sent unconditionally. Since `app.js` ships with the server and handles `STATUS:` before frame parsing, there's no separately versioned client compatibility concern.

Closes #62

Show a status toast while YouTube/uncached URLs are being resolved instead of leaving the player stuck on "Buffering...".

## Changes

* Send `STATUS:FETCHING_YT` before resolving remote URLs.
* Handle `STATUS:` messages before frame parsing.
* Show a sticky toast until the first `INIT:`.
* Add `sticky` support to `showToast()` and a `hideToast()` helper.
* Local file playback is unchanged.

## Tested

* YouTube URL: `STATUS:FETCHING_YT` → `INIT`
* Local file: no status message
* Rapid seek/pause/re-init during streaming: no crash

No new dependencies or CSS changes.
